### PR TITLE
Fixed CSS display of Note.

### DIFF
--- a/src/css/editor.css
+++ b/src/css/editor.css
@@ -113,8 +113,6 @@ body {
 
 /* special handling for note type entities */
 .citation, .note, .keyword {
-	height: 16px !important;
-	width: 16px !important;
 	cursor: pointer;
 }
 


### PR DESCRIPTION
Caused the "Note:" label to look messed up.
